### PR TITLE
Add Recruiter-Only Functionality

### DIFF
--- a/src/components/dashboard/JobSeekerDashboard.tsx
+++ b/src/components/dashboard/JobSeekerDashboard.tsx
@@ -341,10 +341,10 @@ const JobSeekerDashboard: React.FC<JobSeekerDashboardProps> = ({ user }) => {
               
               <div className="flex justify-center mt-4">
                 <a 
-                  href="#" 
+                  href="/jobs" 
                   className="inline-block text-primary-600 hover:text-primary-800 font-medium"
                 >
-                  Beheer je sollicitatiekalender
+                  Vind interessante vacatures
                 </a>
               </div>
             </div>

--- a/src/components/profile/DetailedCVForm.tsx
+++ b/src/components/profile/DetailedCVForm.tsx
@@ -1344,6 +1344,21 @@ const DetailedCVForm: React.FC<DetailedCVFormProps> = ({
           </button>
         </div>
       </form>
+
+      {/* Link om een nieuwe afspraak toe te voegen, alleen tonen voor recruiters */}
+      {user.role === 'recruiter' && (
+        <div className="flex justify-end">
+          <a 
+            href="/schedule-meeting" 
+            className="inline-flex items-center px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-md"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clipRule="evenodd" />
+            </svg>
+            Nieuwe afspraak plannen
+          </a>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../contexts/AuthContext';
 import Header from '../components/common/Header';
 import Footer from '../components/common/Footer';
 import { isRecruiter } from '../types/user';
+import { Navigate } from 'react-router-dom';
 
 interface Meeting {
   id: string;
@@ -29,9 +30,30 @@ const Calendar: React.FC = () => {
   const [currentMonth, setCurrentMonth] = useState<number>(new Date().getMonth());
   const [currentYear, setCurrentYear] = useState<number>(new Date().getFullYear());
   const [selectedDayMeetings, setSelectedDayMeetings] = useState<Meeting[]>([]);
+  const [showRestrictionMessage, setShowRestrictionMessage] = useState<boolean>(false);
 
   // Controleer of de gebruiker een recruiter is
   const isUserRecruiter = isRecruiter(userProfile);
+
+  // Redirect of toon beperkingsmelding als de gebruiker geen recruiter is
+  if (!isUserRecruiter) {
+    return (
+      <div className="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center z-50">
+        <div className="bg-white p-8 rounded-lg shadow-xl max-w-md">
+          <h2 className="text-xl font-semibold mb-4">Deze functie is momenteel alleen beschikbaar voor recruiters.</h2>
+          <p className="mb-6">Als werkzoekende kun je alleen afspraken ontvangen van recruiters.</p>
+          <div className="text-right">
+            <a 
+              href="/dashboard" 
+              className="px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-md"
+            >
+              Sluit
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   // Haal alle meetings op voor deze gebruiker
   useEffect(() => {

--- a/src/pages/ScheduleMeeting.tsx
+++ b/src/pages/ScheduleMeeting.tsx
@@ -6,6 +6,7 @@ import { useForm, Controller, SubmitHandler } from 'react-hook-form';
 import Header from '../components/common/Header';
 import Footer from '../components/common/Footer';
 import { useAuth } from '../contexts/AuthContext';
+import { isRecruiter } from '../types/user';
 
 interface CandidateBasicData {
   id: string;
@@ -46,6 +47,29 @@ const ScheduleMeeting: React.FC = () => {
   // State voor huidige maand en jaar in de kalender
   const [currentMonth, setCurrentMonth] = useState<number>(new Date().getMonth());
   const [currentYear, setCurrentYear] = useState<number>(new Date().getFullYear());
+  
+  // Controleer of de gebruiker een recruiter is
+  const isUserRecruiter = isRecruiter(userProfile);
+
+  // Redirect of toon beperkingsmelding als de gebruiker geen recruiter is
+  if (!isUserRecruiter) {
+    return (
+      <div className="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center z-50">
+        <div className="bg-white p-8 rounded-lg shadow-xl max-w-md">
+          <h2 className="text-xl font-semibold mb-4">Deze functie is momenteel alleen beschikbaar voor recruiters.</h2>
+          <p className="mb-6">Als werkzoekende kun je alleen afspraken ontvangen van recruiters.</p>
+          <div className="text-right">
+            <a 
+              href="/dashboard" 
+              className="px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-md"
+            >
+              Sluit
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
   
   const { 
     register, 


### PR DESCRIPTION
Overview
This PR implements access restrictions to ensure that only users with a recruiter role can access certain features of the application.

Changes
- Added access control checks to `Calendar.tsx` component, displaying a restriction message for non-recruiter users
- Added similar access control to the `ScheduleMeeting.tsx` component
- Made minor updates to `JobSeekerDashboard.tsx` for consistency
- Leveraged the existing `isRecruiter()` utility function from user types

Why this is needed
These changes improve the application's security and user experience by clearly indicating which features are available to different user roles. Non-recruiter users will now see an appropriate message when trying to access recruiter-only features, rather than experiencing unexpected behavior.

Testing
- Verified that the calendar and scheduling components correctly restrict access for non-recruiter users
- Confirmed that recruiters maintain full access to these features
- Tested that the restriction message displays properly on various screen sizes