### PR TITLE
Hide Recruiter-Only Features for Non-Recruiters

### DIFF
--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -30,29 +30,13 @@ const Calendar: React.FC = () => {
   const [currentMonth, setCurrentMonth] = useState<number>(new Date().getMonth());
   const [currentYear, setCurrentYear] = useState<number>(new Date().getFullYear());
   const [selectedDayMeetings, setSelectedDayMeetings] = useState<Meeting[]>([]);
-  const [showRestrictionMessage, setShowRestrictionMessage] = useState<boolean>(false);
 
   // Controleer of de gebruiker een recruiter is
   const isUserRecruiter = isRecruiter(userProfile);
 
-  // Redirect of toon beperkingsmelding als de gebruiker geen recruiter is
+  // Direct redirect naar dashboard als de gebruiker geen recruiter is
   if (!isUserRecruiter) {
-    return (
-      <div className="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center z-50">
-        <div className="bg-white p-8 rounded-lg shadow-xl max-w-md">
-          <h2 className="text-xl font-semibold mb-4">Deze functie is momenteel alleen beschikbaar voor recruiters.</h2>
-          <p className="mb-6">Als werkzoekende kun je alleen afspraken ontvangen van recruiters.</p>
-          <div className="text-right">
-            <a 
-              href="/dashboard" 
-              className="px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-md"
-            >
-              Sluit
-            </a>
-          </div>
-        </div>
-      </div>
-    );
+    return <Navigate to="/dashboard" />;
   }
 
   // Haal alle meetings op voor deze gebruiker

--- a/src/pages/ScheduleMeeting.tsx
+++ b/src/pages/ScheduleMeeting.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Navigate } from 'react-router-dom';
 import { doc, getDoc, collection, addDoc, Timestamp, getDocs, query, where, orderBy } from 'firebase/firestore';
 import { db } from '../firebase/config';
 import { useForm, Controller, SubmitHandler } from 'react-hook-form';
@@ -51,24 +51,9 @@ const ScheduleMeeting: React.FC = () => {
   // Controleer of de gebruiker een recruiter is
   const isUserRecruiter = isRecruiter(userProfile);
 
-  // Redirect of toon beperkingsmelding als de gebruiker geen recruiter is
+  // Direct redirect naar dashboard als de gebruiker geen recruiter is
   if (!isUserRecruiter) {
-    return (
-      <div className="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center z-50">
-        <div className="bg-white p-8 rounded-lg shadow-xl max-w-md">
-          <h2 className="text-xl font-semibold mb-4">Deze functie is momenteel alleen beschikbaar voor recruiters.</h2>
-          <p className="mb-6">Als werkzoekende kun je alleen afspraken ontvangen van recruiters.</p>
-          <div className="text-right">
-            <a 
-              href="/dashboard" 
-              className="px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-md"
-            >
-              Sluit
-            </a>
-          </div>
-        </div>
-      </div>
-    );
+    return <Navigate to="/dashboard" />;
   }
   
   const { 


### PR DESCRIPTION
Problem
Currently, non-recruiter users see buttons/features that are meant for recruiters only, but receive a warning message when trying to use them. This creates a confusing user experience and doesn't properly restrict access to recruiter-specific functionality.

Changes
- Modified `Calendar.tsx` to directly redirect non-recruiters to the dashboard instead of showing a warning modal
- Modified `ScheduleMeeting.tsx` to directly redirect non-recruiters to the dashboard instead of showing a warning modal
- Ensured consistent behavior across the application for recruiter-only features

Why this is needed
This improves security and user experience by ensuring that non-recruiter users cannot access pages or features intended solely for recruiters. By using redirects instead of warnings, we create a cleaner user interface where users only see what they have permission to access.

Testing
- Verified that non-recruiter users are properly redirected when attempting to access recruiter-only pages
- Confirmed that recruiter users retain full access to all features